### PR TITLE
Change default ActiveSupport::KeyGenerator.hash_digest_class to SHA256

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -21,7 +21,7 @@ module ActiveSupport
       end
 
       def hash_digest_class
-        @hash_digest_class ||= OpenSSL::Digest::SHA1
+        @hash_digest_class ||= OpenSSL::Digest::SHA256
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`ActiveSupport::KeyGenerator.hash_digest_class` will produce  `OpenSSL::Digest::SHA1` by default if the configuration hash digest class has not been set up, even though the [default hash digest class](https://guides.rubyonrails.org/configuring.html#config-active-support-key-generator-hash-digest-class) for ActiveSupport::KeyGenerator is `SHA256`.

After the initialization of the hash digest class, `ActiveSupport::KeyGenerator.hash_digest_class` correctly outputs `OpenSSL::Digest::SHA256`


### Detail

This Pull Request has been created to set the default `hash_digest_class` to `SHA256` before the hash digest class has been initialized. 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
